### PR TITLE
Add - and @ as key characters

### DIFF
--- a/src/main/resources/templates/authentication-action/debug-attribute/index.vm
+++ b/src/main/resources/templates/authentication-action/debug-attribute/index.vm
@@ -152,7 +152,7 @@
         return r + (pEnd || '');
         },
     prettyPrint: function(obj) {
-        var jsonLine = /^( *)("[\w]+": )?("[^"]*"|[\w.+-]*)?([,[{])?$/mg;
+        var jsonLine = /^( *)("[\w-\@]+": )?("[^"]*"|[\w.+-]*)?([,[{])?$/mg;
         return JSON.stringify(obj, null, 3)
             .replace(/&/g, '&amp;').replace(/\\"/g, '&quot;')
             .replace(/</g, '&lt;').replace(/>/g, '&gt;')


### PR DESCRIPTION
The debug prompt was mis-representing keys with `-` and `@` in them. 

![Failed parse](https://github.com/curityio/debug-attribute-action/assets/15199935/6fdcebca-b79a-4518-bfad-10268e619051)


![Corrected key](https://github.com/curityio/debug-attribute-action/assets/15199935/2e3fdda6-2d04-49bb-8252-f3f5511bda64)
