### PR TITLE
fix: render attribute JSON in Safari using textContent

### DIFF
--- a/src/main/resources/templates/authentication-action/debug-attribute/index.vm
+++ b/src/main/resources/templates/authentication-action/debug-attribute/index.vm
@@ -128,7 +128,7 @@
     </div>
     <pre class="json-pretty json-pretty-action"></pre>
 
-        <button type="submit" class="button button-fullwidth $!button_color mt2">Continue</button>
+    <button type="submit" class="button button-fullwidth button-primary mt2">Continue</button>
 
     </form>
 
@@ -161,9 +161,9 @@
         }
     };
 
-    var subjectJSON = document.querySelector('.subject-json').innerText
-    var contextJSON = document.querySelector('.context-json').innerText
-    var actionJSON = document.querySelector('.action-json').innerText
+    var subjectJSON = document.querySelector('.subject-json').textContent
+    var contextJSON = document.querySelector('.context-json').textContent
+    var actionJSON = document.querySelector('.action-json').textContent
 
     document.querySelector('.json-pretty-subject').innerHTML = library.json.prettyPrint(JSON.parse(`[${subjectJSON}]`))
     document.querySelector('.json-pretty-context').innerHTML = library.json.prettyPrint(JSON.parse(`[${contextJSON}]`))


### PR DESCRIPTION
## Problem

The debug-attribute action page renders the **Subject / Context / Action** attribute JSON inside hidden `<code class="...-json hide">` elements (`.hide` is `display:none`) and uses an inline script to pretty-print them into the visible `<pre>` blocks.

The script read those elements with **`.innerText`**. WebKit/Safari returns an **empty string** for `innerText` of a `display:none` element, whereas Chrome falls back to the underlying text. The result: the JSON blocks rendered as empty boxes in **Safari** while working correctly in **Chrome**.

| Chrome | Safari (before) |
|---|---|
| JSON renders | empty `[]` boxes |

## Fix

- Switch the three `.innerText` reads to **`.textContent`**, which ignores CSS rendering state and behaves consistently across browsers (and is the value we actually want — the raw JSON the server wrote into the element).
- Replace the dead `$!button_color` Velocity quiet-reference on the **Continue** button with the literal `button-primary` class. It was never populated by the plugin or a theme, so it silently rendered as nothing.

## Testing

Built the plugin and deployed it to a local Curity Identity Server (11.x), attached the action to an authenticator, and confirmed the Subject/Context/Action JSON now renders in **Safari** as it already did in Chrome. `Copy JSON` (which uses `.innerHTML`) was unaffected.

## Notes

- Template-only change; no Java changes. Plugin version left at `1.4.3` — let me know if you'd prefer a `1.4.4` bump for release.

## Screenshot

<img width="3344" height="2214" alt="CleanShot 2026-06-03 at 17 18 32@2x" src="https://github.com/user-attachments/assets/e43249fd-5be0-41b8-8ba9-eee16c3ceff5" />

